### PR TITLE
PR to improve tests by requiring callback fn only for async tests

### DIFF
--- a/Section 6/Adding Unit Tests/test/unit.js
+++ b/Section 6/Adding Unit Tests/test/unit.js
@@ -13,25 +13,30 @@ var assert = require('assert');
 var unit = {};
 
 
+/*
+ * PR for final Exam
+ * All sync test does not require callback (done) function
+ */
+
 // Assert that the getANumber function is returning a number
-unit['helpers.getANumber should return a number'] = function(done){
+unit['helpers.getANumber should return a number'] = function(/* done */){
   var val = helpers.getANumber();
   assert.equal(typeof(val), 'number');
-  done();
+  // done();
 };
 
 // Assert that the getANumber function is returning 1
-unit['helpers.getANumber should return 1'] = function(done){
+unit['helpers.getANumber should return 1'] = function(/* done */){
   var val = helpers.getANumber();
   assert.equal(val, 1);
-  done();
+  // done();
 };
 
 // Assert that the getANumber function is returning 2
-unit['helpers.getNumberOne should return 2'] = function(done){
+unit['helpers.getNumberOne should return 2'] = function(/* done */){
   var val = helpers.getANumber();
   assert.equal(val, 2);
-  done();
+  // done();
 };
 
 // Logs.list should callback an array and a false error
@@ -55,10 +60,10 @@ unit['logs.truncate should not throw if the logId does not exist, should callbac
 };
 
 // exampleDebuggingProblem.init should not throw (but it does)
-unit['exampleDebuggingProblem.init should not throw when called'] = function(done){
+unit['exampleDebuggingProblem.init should not throw when called'] = function(/* done */){
   assert.doesNotThrow(function(){
     exampleDebuggingProblem.init();
-    done();
+    // done();
   },TypeError);
 };
 


### PR DESCRIPTION
Section 6 - Adding Unit Tests modified to make testing more flexible.

Synchronous tests like:
```javascript
// Assert that the getANumber function is returning 1
unit['helpers.getANumber should return 1'] = function(/* done */){
  var val = helpers.getANumber();
  assert.equal(val, 1);
  // done();
};
```

Does not require callback function (done) anymore.

On the other hand, async tests still works when callback function is passed:
```javascript
// Logs.list should callback an array and a false error
unit['logs.list should callback a false error and an array of log names'] = function(done){
  logs.list(true,function(err,logFileNames){
      assert.equal(err, false);
      assert.ok(logFileNames instanceof Array);
      assert.ok(logFileNames.length > 1);
      done();
  });
};
```

So test runner now is more flexible and reduces boilerplate for sync functions.

