### PR TITLE
Followable readme.md files with links to lesson contents

### DIFF
--- a/Section 1/Bonus-Lectures.md
+++ b/Section 1/Bonus-Lectures.md
@@ -1,0 +1,23 @@
+# NEW: Bonus Lectures
+
+The changes to Node since 2018 have not been substantive enough to merit releasing a whole new version of this course (see previous slide for details). Eventually (someday) Node will release a huge change that makes us need to redevelop the course, but that hasn't happened yet.
+
+That being said, there are a few topics we wished we'd addressed in this course, but didn't. So we've created bonus lectures for them and put them on Youtube. These are answers to common issues that students run into as they take this course. You can ignore these lectures for now. But just be aware that they're here if/when you need them:
+
+
+## TypeError: Cannot convert object to primitive value
+
+[https://youtu.be/7pwHtlD-u6U]
+
+## Error: Can't set headers after they are sent.
+
+[https://youtu.be/rKTlakY8j2M]
+
+## All About Truncation
+
+[https://youtu.be/NklJesn2xJc]
+
+## Why Isn't HTTPS Working?
+
+[https://youtu.be/h9wGogmXYzk]
+

--- a/Section 1/Changes.md
+++ b/Section 1/Changes.md
@@ -1,0 +1,60 @@
+# Changes
+
+## NEW: Changes for 2024
+
+This document was last revised on March 1st, 2024
+
+This course was originally released in 2018. Since then, the Node.js platform and ecosystem has continued to evolve. Here are the important changes that have happened since then, that you should be aware of:
+
+
+### New version of Node:
+
+The current stable version of Node (as of March 2024) is 20.11.1. That's the one you should be downloading and using.
+
+You can download it here: [https://nodejs.org/en/]
+You can read the docs here: [https://nodejs.org/docs/latest-v20.x/api/index.html]
+
+
+### Use fs.ftruncate instead of fs.truncate
+
+In newer versions of Node the name of the function used for file truncation has changed. As you watch the videos you'll see us refer to fs.truncate. You should be use fs.ftruncate instead (notice the exta "f" in the function name). You can see examples of how to use it here:
+
+[https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_ftruncate_fd_len_callback]
+
+
+### Node now has better support for ES6+
+
+Newer node systems have better support for ES6 and beyond. The code presented in this course is ES5. If you use a newer version of Node we'd recommend using promises or async/await instead of getting into "callback hell". If you'd like to learn how to change ES5 syntax into ES6 , then check out our "Keeping up with the Javascripts" course. If you'd rather stick is ES5 that's fine as well. If you use ES6+ then you need to be careful about how you use the "import" syntax (in place of "require").  It's still tricky. Read this...
+
+[https://nodejs.org/api/esm.html]
+
+...and take careful note of these caveats:
+
+[https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_differences_between_es_modules_and_commonjs]
+
+
+### Sorry, still no TypeScript support
+
+Node still does not natively support TypeScript. If you want to use TS (which we don't actually recommend), you'll need to use a transpiler or a build system with this package. Again, we don't like this approach because we think it's already hard enough to debug Node's cryptic error messages without also having to figure out which line number in the error message equates to which line number in the original TS files. After you get super-comfortable with Node and have experience debugging it, then you could consider using TS without issues. But if you're just getting started, then using TS is setting yourself up for a world of pain.
+
+
+### New Experimental Modules
+
+The end of this course dives into bleeding-edge / experimental modules in Node. These are changing constantly. To see the latest experimental modules in the next version of node check out these docs here:
+
+[https://nodejs.org/docs/latest/api/]
+
+
+### This class has some bonus lectures
+
+You'll see the details on the next slide in this course.
+
+### Less Technical News
+
+In less technical news, here are some interesting updates about the Node world. As you watch the lecture on "The Story of Node.js", you should keep these developments in mind as an addendum:
+
+1. The Node.js project has moved yet again. Their new home is The Open JS foundation: [https://openjsf.org/]
+
+2. Ryan Dahl (the author of Node) started a new project called Deno. It's arguably a Node.js competitor, and is built in Rust. Who knows what the future will bring. Will the projects merge together like Node did with io.js, or will they stay separate? We'll see. Find more here: [https://deno.land] and here: [https://github.com/denoland/deno] and read this too: [https://thenewstack.io/how-node-js-is-addressing-the-challenge-of-ryan-dahls-deno/]
+
+3. NPM was sold to Github, which itself previously sold to Microsoft. So now Microsoft is technically the parent of Github and Github is the parent of NPM. More details here: [https://www.cnbc.com/2020/03/16/microsoft-github-agrees-to-buy-code-distribution-start-up-npm.html]

--- a/Section 1/readme.md
+++ b/Section 1/readme.md
@@ -1,5 +1,5 @@
 # Section 1: Course Overview
 
-[Changes for 2024](/blob/master/Section%201/Changes.md)
+[Changes for 2024](/Section%201/Changes.md)
 
-[Bonus Lectures](/blob/master/Section%201/Bonus-Lectures.md)
+[Bonus Lectures](/Section%201/Bonus-Lectures.md)

--- a/Section 1/readme.md
+++ b/Section 1/readme.md
@@ -1,0 +1,5 @@
+# Section 1: Course Overview
+
+[Changes for 2024](/blob/master/Section%201/Changes.md)
+
+[Bonus Lectures](/blob/master/Section%201/Bonus-Lectures.md)

--- a/Section 2/readme.md
+++ b/Section 2/readme.md
@@ -1,0 +1,5 @@
+# Section 2: Background Information
+
+[Anatomy of a Node Application](/tree/master/Section%202/Anatomy%20of%20a%20Node%20Application)
+
+[Common Node Conventions](/tree/master/Section%202/Common%20Node%20Conventions)

--- a/Section 2/readme.md
+++ b/Section 2/readme.md
@@ -1,5 +1,5 @@
 # Section 2: Background Information
 
-[Anatomy of a Node Application](/tree/master/Section%202/Anatomy%20of%20a%20Node%20Application)
+[Anatomy of a Node Application](/Section%202/Anatomy%20of%20a%20Node%20Application)
 
-[Common Node Conventions](/tree/master/Section%202/Common%20Node%20Conventions)
+[Common Node Conventions](/Section%202/Common%20Node%20Conventions)

--- a/Section 3/readme.md
+++ b/Section 3/readme.md
@@ -1,43 +1,43 @@
 # Section 3: Building a RESTful API
 
-[Basic Scaffolding](/tree/master/Section%203/Basic%20Scaffolding)
+[Basic Scaffolding](/Section%203/Basic%20Scaffolding)
 
-[Starting a Server](/tree/master/Section%203/Starting%20a%20Server)
+[Starting a Server](/Section%203/Starting%20a%20Server)
 
-[Parsing Request Paths](/tree/master/Section%203/Parsing%20Request%20Paths)
+[Parsing Request Paths](/Section%203/Parsing%20Request%20Paths)
 
-[Parsing HTTP Methods](/tree/master/Section%203/Parsing%20HTTP%20Methods)
+[Parsing HTTP Methods](/Section%203/Parsing%20HTTP%20Methods)
 
-[Parsing Query Strings](/tree/master/Section%203/Parsing%20Query%20Strings)
+[Parsing Query Strings](/Section%203/Parsing%20Query%20Strings)
 
-[Parsing Headers](/tree/master/Section%203/Parsing%20Headers)
+[Parsing Headers](/Section%203/Parsing%20Headers)
 
-[Parsing Payloads](/tree/master/Section%203/Parsing%20Payloads)
+[Parsing Payloads](/Section%203/Parsing%20Payloads)
 
-[Routing Requests](/tree/master/Section%203/Routing%20Requests)
+[Routing Requests](/Section%203/Routing%20Requests)
 
-[Returning JSON](/tree/master/Section%203/Returning%20JSON)
+[Returning JSON](/Section%203/Returning%20JSON)
 
-[Adding Configuration](/tree/master/Section%203/Adding%20Configuration)
+[Adding Configuration](/Section%203/Adding%20Configuration)
 
-[Adding HTTPS support](/tree/master/Section%203/Adding%20HTTPS%20support)
+[Adding HTTPS support](/Section%203/Adding%20HTTPS%20support)
 
-[Storing Data](/tree/master/Section%203/Storing%20Data)
+[Storing Data](/Section%203/Storing%20Data)
 
-[Service 1 - Ping](/tree/master/Section%203/Service%201%20-%20Ping)
+[Service 1 - Ping](/Section%203/Service%201%20-%20Ping)
 
-[Service 2 - Users](/tree/master/Section%203/Service%202%20-%20Users)
+[Service 2 - Users](/Section%203/Service%202%20-%20Users)
 
-[Service 3 - Tokens](/tree/master/Section%203Service%203%20-%20Tokens/)
+[Service 3 - Tokens](/Section%203Service%203%20-%20Tokens/)
 
-[Service 4 - Checks](/tree/master/Section%203/Service%204%20-%20Checks)
+[Service 4 - Checks](/Section%203/Service%204%20-%20Checks)
 
-[Connecting to an API](/tree/master/Section%203/Connecting%20to%20an%20API)
+[Connecting to an API](/Section%203/Connecting%20to%20an%20API)
 
-[Background Workers](/tree/master/Section%203/Background%20Workers)
+[Background Workers](/Section%203/Background%20Workers)
 
-[Logging to Files](/tree/master/Section%203/Logging%20to%20Files)
+[Logging to Files](/Section%203/Logging%20to%20Files)
 
-[Logging to Console](/tree/master/Section%203/Logging%20to%20Console)
+[Logging to Console](/Section%203/Logging%20to%20Console)
 
-[FINAL](/tree/master/Section%203/FINAL)
+[FINAL](/Section%203/FINAL)

--- a/Section 3/readme.md
+++ b/Section 3/readme.md
@@ -28,7 +28,7 @@
 
 [Service 2 - Users](/Section%203/Service%202%20-%20Users)
 
-[Service 3 - Tokens](/Section%203Service%203%20-%20Tokens/)
+[Service 3 - Tokens](/Section%203/Service%203%20-%20Tokens)
 
 [Service 4 - Checks](/Section%203/Service%204%20-%20Checks)
 

--- a/Section 3/readme.md
+++ b/Section 3/readme.md
@@ -1,0 +1,43 @@
+# Section 3: Building a RESTful API
+
+[Basic Scaffolding](/tree/master/Section%203/Basic%20Scaffolding)
+
+[Starting a Server](/tree/master/Section%203/Starting%20a%20Server)
+
+[Parsing Request Paths](/tree/master/Section%203/Parsing%20Request%20Paths)
+
+[Parsing HTTP Methods](/tree/master/Section%203/Parsing%20HTTP%20Methods)
+
+[Parsing Query Strings](/tree/master/Section%203/Parsing%20Query%20Strings)
+
+[Parsing Headers](/tree/master/Section%203/Parsing%20Headers)
+
+[Parsing Payloads](/tree/master/Section%203/Parsing%20Payloads)
+
+[Routing Requests](/tree/master/Section%203/Routing%20Requests)
+
+[Returning JSON](/tree/master/Section%203/Returning%20JSON)
+
+[Adding Configuration](/tree/master/Section%203/Adding%20Configuration)
+
+[Adding HTTPS support](/tree/master/Section%203/Adding%20HTTPS%20support)
+
+[Storing Data](/tree/master/Section%203/Storing%20Data)
+
+[Service 1 - Ping](/tree/master/Section%203/Service%201%20-%20Ping)
+
+[Service 2 - Users](/tree/master/Section%203/Service%202%20-%20Users)
+
+[Service 3 - Tokens](/tree/master/Section%203Service%203%20-%20Tokens/)
+
+[Service 4 - Checks](/tree/master/Section%203/Service%204%20-%20Checks)
+
+[Connecting to an API](/tree/master/Section%203/Connecting%20to%20an%20API)
+
+[Background Workers](/tree/master/Section%203/Background%20Workers)
+
+[Logging to Files](/tree/master/Section%203/Logging%20to%20Files)
+
+[Logging to Console](/tree/master/Section%203/Logging%20to%20Console)
+
+[FINAL](/tree/master/Section%203/FINAL)

--- a/Section 4/readme.md
+++ b/Section 4/readme.md
@@ -1,0 +1,29 @@
+# Section 4: Building a Web App GUI
+
+[Refactoring for a GUI](/tree/master/Section%204/Refactoring%20for%20a%20GUI)
+
+[Using Templates](/tree/master/Section%204/Using%20Templates)
+
+[Serving Static Assets](/tree/master/Section%204/Serving%20Static%20Assets)
+
+[Making AJAX Requests](/tree/master/Section%204/Making%20AJAX%20Requests)
+
+[Page 1 - Index](/tree/master/Section%204/Page%201%20-%20Index)
+
+[Page 2 - Create Account](/tree/master/Section%204/Page%202%20-%20Create%20Account)
+
+[Page 3 - Create Session](/tree/master/Section%204/Page%203%20-%20Create%20Session)
+
+[Page 4 - Deleted Session](/tree/master/Section%204/Page%204%20-%20Deleted%20Session)
+
+[Page 5 - Edit Account](/tree/master/Section%204/Page%205%20-%20Edit%20Account)
+
+[Page 6 - Deleted Account](/tree/master/Section%204/Page%206%20-%20Deleted%20Account)
+
+[Page 7 - Create A Check](/tree/master/Section%204/Page%207%20-%20Create%20A%20Check)
+
+[Page 8 - Dashboard](/tree/master/Section%204/Page%208%20-%20Dashboard)
+
+[Page 9 - Edit A Check](/tree/master/Section%204/Page%209%20-%20Edit%20A%20Check)
+
+[FINAL](/tree/master/Section%204/FINAL)

--- a/Section 4/readme.md
+++ b/Section 4/readme.md
@@ -1,29 +1,29 @@
 # Section 4: Building a Web App GUI
 
-[Refactoring for a GUI](/tree/master/Section%204/Refactoring%20for%20a%20GUI)
+[Refactoring for a GUI](/Section%204/Refactoring%20for%20a%20GUI)
 
-[Using Templates](/tree/master/Section%204/Using%20Templates)
+[Using Templates](/Section%204/Using%20Templates)
 
-[Serving Static Assets](/tree/master/Section%204/Serving%20Static%20Assets)
+[Serving Static Assets](/Section%204/Serving%20Static%20Assets)
 
-[Making AJAX Requests](/tree/master/Section%204/Making%20AJAX%20Requests)
+[Making AJAX Requests](/Section%204/Making%20AJAX%20Requests)
 
-[Page 1 - Index](/tree/master/Section%204/Page%201%20-%20Index)
+[Page 1 - Index](/Section%204/Page%201%20-%20Index)
 
-[Page 2 - Create Account](/tree/master/Section%204/Page%202%20-%20Create%20Account)
+[Page 2 - Create Account](/Section%204/Page%202%20-%20Create%20Account)
 
-[Page 3 - Create Session](/tree/master/Section%204/Page%203%20-%20Create%20Session)
+[Page 3 - Create Session](/Section%204/Page%203%20-%20Create%20Session)
 
-[Page 4 - Deleted Session](/tree/master/Section%204/Page%204%20-%20Deleted%20Session)
+[Page 4 - Deleted Session](/Section%204/Page%204%20-%20Deleted%20Session)
 
-[Page 5 - Edit Account](/tree/master/Section%204/Page%205%20-%20Edit%20Account)
+[Page 5 - Edit Account](/Section%204/Page%205%20-%20Edit%20Account)
 
-[Page 6 - Deleted Account](/tree/master/Section%204/Page%206%20-%20Deleted%20Account)
+[Page 6 - Deleted Account](/Section%204/Page%206%20-%20Deleted%20Account)
 
-[Page 7 - Create A Check](/tree/master/Section%204/Page%207%20-%20Create%20A%20Check)
+[Page 7 - Create A Check](/Section%204/Page%207%20-%20Create%20A%20Check)
 
-[Page 8 - Dashboard](/tree/master/Section%204/Page%208%20-%20Dashboard)
+[Page 8 - Dashboard](/Section%204/Page%208%20-%20Dashboard)
 
-[Page 9 - Edit A Check](/tree/master/Section%204/Page%209%20-%20Edit%20A%20Check)
+[Page 9 - Edit A Check](/Section%204/Page%209%20-%20Edit%20A%20Check)
 
-[FINAL](/tree/master/Section%204/FINAL)
+[FINAL](/Section%204/FINAL)

--- a/Section 5/readme.md
+++ b/Section 5/readme.md
@@ -1,0 +1,26 @@
+# Section 5: Building a CLI
+
+[Adding a CLI](/tree/master/Section%205/Adding%20a%20CLI)
+
+[Handling Events](/tree/master/Section%205/Handling%20Events)
+
+[Command 1 - Exit](/tree/master/Section%205/Command%201%20-%20Exit)
+
+[Command 2 - Man or Help](/tree/master/Section%205/Command%202%20-%20Man%20or%20Help)
+
+[Command 3 - Stats](/tree/master/Section%205/Command%203%20-%20Stats)
+
+[Command 4 - List Users](/tree/master/Section%205/Command%204%20-%20List%20Users)
+
+[Command 5 - More User Info](/tree/master/Section%205/Command%205%20-%20More%20User%20Info)
+
+[Command 6 - List Checks](/tree/master/Section%205/Command%206%20-%20List%20Checks)
+
+[Command 7 - More Check Info](/tree/master/Section%205/Command%207%20-%20More%20Check%20Info)
+
+[Command 8 - List Logs](/tree/master/Section%205/Command%208%20-%20List%20Logs)
+
+[Command 9 - More Log Info](/tree/master/Section%205/Command%209%20-%20More%20Log%20Info)
+
+[FINAL](/tree/master/Section%205/FINAL)
+

--- a/Section 5/readme.md
+++ b/Section 5/readme.md
@@ -1,26 +1,26 @@
 # Section 5: Building a CLI
 
-[Adding a CLI](/tree/master/Section%205/Adding%20a%20CLI)
+[Adding a CLI](/Section%205/Adding%20a%20CLI)
 
-[Handling Events](/tree/master/Section%205/Handling%20Events)
+[Handling Events](/Section%205/Handling%20Events)
 
-[Command 1 - Exit](/tree/master/Section%205/Command%201%20-%20Exit)
+[Command 1 - Exit](/Section%205/Command%201%20-%20Exit)
 
-[Command 2 - Man or Help](/tree/master/Section%205/Command%202%20-%20Man%20or%20Help)
+[Command 2 - Man or Help](/Section%205/Command%202%20-%20Man%20or%20Help)
 
-[Command 3 - Stats](/tree/master/Section%205/Command%203%20-%20Stats)
+[Command 3 - Stats](/Section%205/Command%203%20-%20Stats)
 
-[Command 4 - List Users](/tree/master/Section%205/Command%204%20-%20List%20Users)
+[Command 4 - List Users](/Section%205/Command%204%20-%20List%20Users)
 
-[Command 5 - More User Info](/tree/master/Section%205/Command%205%20-%20More%20User%20Info)
+[Command 5 - More User Info](/Section%205/Command%205%20-%20More%20User%20Info)
 
-[Command 6 - List Checks](/tree/master/Section%205/Command%206%20-%20List%20Checks)
+[Command 6 - List Checks](/Section%205/Command%206%20-%20List%20Checks)
 
-[Command 7 - More Check Info](/tree/master/Section%205/Command%207%20-%20More%20Check%20Info)
+[Command 7 - More Check Info](/Section%205/Command%207%20-%20More%20Check%20Info)
 
-[Command 8 - List Logs](/tree/master/Section%205/Command%208%20-%20List%20Logs)
+[Command 8 - List Logs](/Section%205/Command%208%20-%20List%20Logs)
 
-[Command 9 - More Log Info](/tree/master/Section%205/Command%209%20-%20More%20Log%20Info)
+[Command 9 - More Log Info](/Section%205/Command%209%20-%20More%20Log%20Info)
 
-[FINAL](/tree/master/Section%205/FINAL)
+[FINAL](/Section%205/FINAL)
 

--- a/Section 6/readme.md
+++ b/Section 6/readme.md
@@ -1,0 +1,15 @@
+# Section 6: Gaining Stability
+
+[Creating Errors](/tree/master/Section%206/Creating%20Errors)
+
+[Using The Debugg](/tree/master/Section%206/Using%20The%20Debugg)
+
+[Linting With "Strict"](/tree/master/Section%206/Linting%20With%20Strict)
+
+[Adding A Test Runner](/tree/master/Section%206/Adding%20A%20Test%20Runner)
+
+[Adding Unit Tests](/tree/master/Section%206/Adding%20Unit%20Tests)
+
+[Adding API Tests](/tree/master/Section%206/Adding%20API%20Tests)
+
+[FINAL](/tree/master/Section%206/FINAL)

--- a/Section 6/readme.md
+++ b/Section 6/readme.md
@@ -1,15 +1,15 @@
 # Section 6: Gaining Stability
 
-[Creating Errors](/tree/master/Section%206/Creating%20Errors)
+[Creating Errors](/Section%206/Creating%20Errors)
 
-[Using The Debugg](/tree/master/Section%206/Using%20The%20Debugg)
+[Using The Debugg](/Section%206/Using%20The%20Debugg)
 
-[Linting With "Strict"](/tree/master/Section%206/Linting%20With%20Strict)
+[Linting With "Strict"](/Section%206/Linting%20With%20Strict)
 
-[Adding A Test Runner](/tree/master/Section%206/Adding%20A%20Test%20Runner)
+[Adding A Test Runner](/Section%206/Adding%20A%20Test%20Runner)
 
-[Adding Unit Tests](/tree/master/Section%206/Adding%20Unit%20Tests)
+[Adding Unit Tests](/Section%206/Adding%20Unit%20Tests)
 
-[Adding API Tests](/tree/master/Section%206/Adding%20API%20Tests)
+[Adding API Tests](/Section%206/Adding%20API%20Tests)
 
-[FINAL](/tree/master/Section%206/FINAL)
+[FINAL](/Section%206/FINAL)

--- a/Section 7/readme.md
+++ b/Section 7/readme.md
@@ -1,0 +1,11 @@
+# Section 7: Gaining Performance
+
+[Refactoring for Performance](/tree/master/Section%207/Refactoring%20for%20Performance)
+
+[Using Performance Hooks](/tree/master/Section%207/Using%20Performance%20Hooks)
+
+[Using a Cluster](/tree/master/Section%207/Using%20a%20Cluster)
+
+[Using Child Processes](/tree/master/Section%207/Using%20Child%20Processes)
+
+[FINAL](/tree/master/Section%207/FINAL)

--- a/Section 7/readme.md
+++ b/Section 7/readme.md
@@ -1,11 +1,11 @@
 # Section 7: Gaining Performance
 
-[Refactoring for Performance](/tree/master/Section%207/Refactoring%20for%20Performance)
+[Refactoring for Performance](/Section%207/Refactoring%20for%20Performance)
 
-[Using Performance Hooks](/tree/master/Section%207/Using%20Performance%20Hooks)
+[Using Performance Hooks](/Section%207/Using%20Performance%20Hooks)
 
-[Using a Cluster](/tree/master/Section%207/Using%20a%20Cluster)
+[Using a Cluster](/Section%207/Using%20a%20Cluster)
 
-[Using Child Processes](/tree/master/Section%207/Using%20Child%20Processes)
+[Using Child Processes](/Section%207/Using%20Child%20Processes)
 
-[FINAL](/tree/master/Section%207/FINAL)
+[FINAL](/Section%207/FINAL)

--- a/Section 8/readme.md
+++ b/Section 8/readme.md
@@ -1,0 +1,17 @@
+# Section 8: Loose Ends
+
+[HTTP2](/tree/master/Section%208/HTTP2)
+
+[VM](/tree/master/Section%208/VM)
+
+[UDP / Datagram](/tree/master/Section%208/UDP)
+
+[Net](/tree/master/Section%208/Net)
+
+[TLS / SSL](/tree/master/Section%208/TLS)
+
+[REPL](/tree/master/Section%208/REPL)
+
+[Async Hooks](/tree/master/Section%208/Async%20Hooks)
+
+[FINAL](/tree/master/Section%208/FINAL)

--- a/Section 8/readme.md
+++ b/Section 8/readme.md
@@ -1,17 +1,17 @@
 # Section 8: Loose Ends
 
-[HTTP2](/tree/master/Section%208/HTTP2)
+[HTTP2](/Section%208/HTTP2)
 
-[VM](/tree/master/Section%208/VM)
+[VM](/Section%208/VM)
 
-[UDP / Datagram](/tree/master/Section%208/UDP)
+[UDP / Datagram](/Section%208/UDP)
 
-[Net](/tree/master/Section%208/Net)
+[Net](/Section%208/Net)
 
-[TLS / SSL](/tree/master/Section%208/TLS)
+[TLS / SSL](/Section%208/TLS)
 
-[REPL](/tree/master/Section%208/REPL)
+[REPL](/Section%208/REPL)
 
-[Async Hooks](/tree/master/Section%208/Async%20Hooks)
+[Async Hooks](/Section%208/Async%20Hooks)
 
-[FINAL](/tree/master/Section%208/FINAL)
+[FINAL](/Section%208/FINAL)

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,19 @@
-# The Node.JS Master Course
+# [The Node.JS Master Course](https://www.pirple.com/courses/take/the-nodejs-master-class)
 
 > Code samples for all sections and chapters.
 
-## Section 1
+## [Section 1: Course Overview](/blob/master/Section%201/readme.md)
 
-## Section 2
+## [Section 2: Background Information](/blob/master/Section%202/readme.md)
 
-## Section 3
+## [Section 3: Building a RESTful API](/blob/master/Section%203/readme.md)
 
-## Section 4
+## [Section 4: Building a Web App GUI](/blob/master/Section%204/readme.md)
 
-## Section 5
+## [Section 5: Building a CLI](/blob/master/Section%205/readme.md)
 
-## Section 6
+## [Section 6: Gaining Stability](/blob/master/Section%206/readme.md)
 
-## Section 7
+## [Section 7: Gaining Performance](/blob/master/Section%207/readme.md)
 
-## Section 8
+## [Section 8: Loose Ends](/blob/master/Section%208/readme.md)

--- a/readme.md
+++ b/readme.md
@@ -2,18 +2,18 @@
 
 > Code samples for all sections and chapters.
 
-## [Section 1: Course Overview](/blob/master/Section%201/readme.md)
+## [Section 1: Course Overview](/Section%201/readme.md)
 
-## [Section 2: Background Information](/blob/master/Section%202/readme.md)
+## [Section 2: Background Information](/Section%202/readme.md)
 
-## [Section 3: Building a RESTful API](/blob/master/Section%203/readme.md)
+## [Section 3: Building a RESTful API](/Section%203/readme.md)
 
-## [Section 4: Building a Web App GUI](/blob/master/Section%204/readme.md)
+## [Section 4: Building a Web App GUI](/Section%204/readme.md)
 
-## [Section 5: Building a CLI](/blob/master/Section%205/readme.md)
+## [Section 5: Building a CLI](/Section%205/readme.md)
 
-## [Section 6: Gaining Stability](/blob/master/Section%206/readme.md)
+## [Section 6: Gaining Stability](/Section%206/readme.md)
 
-## [Section 7: Gaining Performance](/blob/master/Section%207/readme.md)
+## [Section 7: Gaining Performance](/Section%207/readme.md)
 
-## [Section 8: Loose Ends](/blob/master/Section%208/readme.md)
+## [Section 8: Loose Ends](/Section%208/readme.md)


### PR DESCRIPTION
It was difficult to navigate because folders appear out of order and the class does not use "Section" notation. So, this uses readme.md files to organize links to the directories or the few text lessons in the first sections. They appear in the order of the lessons. Links are relative so the pull request should not break them.